### PR TITLE
Break: Add account name and registration key to HostAgentInfo message

### DIFF
--- a/hostagent.proto
+++ b/hostagent.proto
@@ -16,7 +16,7 @@ message HostAgentInfo {
     string hostname = 3;                   // hostname is literally the name of the host itself.
     repeated InstanceInfo instances = 4;   // instances are all the machine instances registered on the machine.
 
-    string account_name = 5;                // account_name is the acccount used in Landscape SaaS.
+    string account_name = 5;                // account_name is the account used in Landscape SaaS.
     optional string registration_key = 6;   // registration_key is an optional account-wide key used to register clients.
 
     // InstanceInfo gather all the information of a given instance.

--- a/hostagent.proto
+++ b/hostagent.proto
@@ -16,6 +16,9 @@ message HostAgentInfo {
     string hostname = 3;                   // hostname is literally the name of the host itself.
     repeated InstanceInfo instances = 4;   // instances are all the machine instances registered on the machine.
 
+    string account_name = 5;                // account_name is the acccount used in Landscape SaaS.
+    optional string registration_key = 6;   // registration_key is an optional account-wide key used to register clients.
+
     // InstanceInfo gather all the information of a given instance.
     message InstanceInfo {
         string id = 1;


### PR DESCRIPTION
The Landscape client sends and `account_name` in order to match the machine to the right account. We need the host to do the same. Similarly, some accounts require a `registration_key`, so it should also be required for the agent.