### PR TITLE
Add default_instance_id to HostAgentInfo message

### DIFF
--- a/hostagent.proto
+++ b/hostagent.proto
@@ -19,6 +19,10 @@ message HostAgentInfo {
     string account_name = 5;                // account_name is the account used in Landscape SaaS.
     optional string registration_key = 6;   // registration_key is an optional account-wide key used to register clients.
 
+    optional string default_instance_id = 7; // default_instance_id is the id of the default instance.
+                                             // The default instance will be empty if there are no instances
+                                             // The default instance will not be in the instances list if it is not managed by the host agent.
+
     // InstanceInfo gather all the information of a given instance.
     message InstanceInfo {
         string id = 1;

--- a/hostagent.proto
+++ b/hostagent.proto
@@ -20,7 +20,7 @@ message HostAgentInfo {
     optional string registration_key = 6;   // registration_key is an optional account-wide key used to register clients.
 
     optional string default_instance_id = 7; // default_instance_id is the id of the default instance.
-                                             // The default instance will be empty if there are no instances
+                                             // The default instance will be empty if there are no instances.
                                              // The default instance will not be in the instances list if it is not managed by the host agent.
 
     // InstanceInfo gather all the information of a given instance.


### PR DESCRIPTION
This way the Landscape server can know which instance is the default one.

Closes #13