### PR TITLE
feat: Present the unmanaged instances

### DIFF
--- a/hostagent.proto
+++ b/hostagent.proto
@@ -25,6 +25,9 @@ message HostAgentInfo {
                                              // The default instance will be empty if there are no instances.
                                              // The default instance will not be in the instances list if it is not managed by the host agent.
 
+    repeated InstanceInfo unmanaged_instances = 8; // unmanaged_instances are all Ubuntu instances
+                                                   // discovered by the agent without voluntary self-introduction.
+
     // InstanceInfo gather all the information of a given instance.
     message InstanceInfo {
         string id = 1;


### PR DESCRIPTION
We discussed a while ago and formalized via the spec WS043 a feature in the hostagent protocol for the agent to report Ubuntu instances discovered by inspection rather than by voluntary self-introduction, which we called unmanaged instances because they are likely not pro-attached nor registered with Landscape and the Windows agent doesn't follow closely their lifecycle nor enforces any particular state.

It's time to bring this to life.

UDENG-7821